### PR TITLE
Add build verification job to CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -304,7 +304,17 @@ jobs:
         run: |
           cd runtime-core
           . ../.venv/bin/activate
-          maturin develop --release
+          maturin build --release
+
+      - name: Install runtime-core wheel
+        run: |
+          . .venv/bin/activate
+          pip install --find-links runtime-core/target/wheels/ runtime_core
+
+      - name: Install backend dependencies
+        run: |
+          . .venv/bin/activate
+          pip install -r backend/requirements.txt
 
       - name: Build wasm-orbit bindings
         run: |
@@ -319,5 +329,6 @@ jobs:
 
       - name: Compile backend
         run: |
+          . .venv/bin/activate
           cd backend
           python -m compileall .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -292,7 +292,10 @@ jobs:
           cache-dependency-path: "frontend/package-lock.json"
 
       - name: Install maturin
-        run: python -m pip install --upgrade pip maturin
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip maturin
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -300,6 +303,7 @@ jobs:
       - name: Build runtime-core (maturin)
         run: |
           cd runtime-core
+          . ../.venv/bin/activate
           maturin develop --release
 
       - name: Build wasm-orbit bindings

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -260,3 +260,60 @@ jobs:
         run: |
           cd frontend
           npm test
+
+  builds:
+    name: Build Artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: "backend/requirements.txt"
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+
+      - name: Install maturin
+        run: python -m pip install --upgrade pip maturin
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Build runtime-core (maturin)
+        run: |
+          cd runtime-core
+          maturin develop --release
+
+      - name: Build wasm-orbit bindings
+        run: |
+          cd wasm-orbit
+          wasm-pack build --target web
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+
+      - name: Compile backend
+        run: |
+          cd backend
+          python -m compileall .


### PR DESCRIPTION
### Motivation

- Ensure builds (Rust/Python/Node/wasm) are validated in CI in addition to running unit tests.
- Catch integration or packaging issues early by compiling `runtime-core`, wasm bindings, frontend assets, and checking backend Python compiles.

### Description

- Add a new `builds` job to `.github/workflows/pytest.yml` that runs on `ubuntu-latest` and checks build artifacts.
- The job sets up `Python 3.11`, `Rust` (stable) with the `wasm32-unknown-unknown` target, and `Node.js 20` and installs `maturin` and `wasm-pack`.
- It runs `maturin develop --release` in `runtime-core`, `wasm-pack build --target web` in `wasm-orbit`, and `npm ci && npm run build` in `frontend`.
- It compiles the backend Python sources with `python -m compileall .` to validate Python code compiles.

### Testing

- No automated tests were executed locally; the change is validated by CI only and will run on pull requests to `main`.
- Existing test jobs (`backend-tests`, `runtime-core-tests`, `frontend-tests`) remain unchanged and will continue to run in CI.
- The new `builds` job will run the build steps described above when the workflow executes in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786349fc1c8329a21d7cc433ca0c49)