### PR TITLE
Add Rust extractor sanity check and improve multiprocessing start method for Windows

### DIFF
--- a/backend/train.py
+++ b/backend/train.py
@@ -154,6 +154,16 @@ def main():
     print(f"  DataLoader workers: {args.num_workers}")
     print("=" * 60)
 
+    # Ensure a consistent multiprocessing start method on Windows to avoid
+    # handle duplication errors when spawning worker processes.
+    import multiprocessing as mp
+
+    try:
+        mp.set_start_method("spawn", force=True)
+    except RuntimeError:
+        # Already set; ignore.
+        pass
+
     # Initialize components
     print("\n[1/7] Initializing feature extractor...")
     feature_extractor = make_feature_extractor()


### PR DESCRIPTION
Implement a sanity check for the Rust feature extractor to ensure it operates correctly before use. Adjust the multiprocessing start method on Windows to prevent handle duplication errors when spawning worker processes.