### PR TITLE
Refactor visual metrics: move runtime/feedback metrics to Rust and add Mandelbrot membership

### DIFF
--- a/backend/examples/benchmark_rendering.py
+++ b/backend/examples/benchmark_rendering.py
@@ -13,12 +13,12 @@ backend_path = Path(__file__).parent.parent
 sys.path.insert(0, str(backend_path))
 
 from src.julia_gpu import GPUJuliaRenderer  # noqa: E402
-from src.visual_metrics import VisualMetrics  # noqa: E402
+from src.visual_metrics import LossVisualMetrics  # noqa: E402
 
 
 def benchmark_old_rendering(num_samples: int = 10):
     """Benchmark old 128x128 rendering with visual_metrics."""
-    visual_metrics = VisualMetrics()
+    visual_metrics = LossVisualMetrics()
 
     seeds = [
         (-0.7, 0.27),

--- a/backend/src/control_trainer.py
+++ b/backend/src/control_trainer.py
@@ -17,7 +17,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from .control_model import AudioToControlModel
 from .data_loader import AudioDataset
-from .visual_metrics import VisualMetrics
+from .visual_metrics import LossVisualMetrics
 from .runtime_core_bridge import (
     DEFAULT_BASE_OMEGA,
     DEFAULT_K_RESIDUALS,
@@ -70,7 +70,7 @@ class ControlTrainer:
     def __init__(
         self,
         model: AudioToControlModel,
-        visual_metrics: VisualMetrics,
+        visual_metrics: LossVisualMetrics,
         feature_extractor: Optional[object] = None,
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
         learning_rate: float = 1e-4,

--- a/backend/stubs/runtime_core/runtime_core.pyi
+++ b/backend/stubs/runtime_core/runtime_core.pyi
@@ -98,6 +98,24 @@ class OrbitState:
         band_gates: Optional[list[float]] = None,
     ) -> Complex: ...
 
+class RuntimeVisualMetrics:
+    edge_density: float
+    color_uniformity: float
+    brightness_mean: float
+    brightness_std: float
+    brightness_range: float
+    mandelbrot_membership: bool
+
+def compute_runtime_visual_metrics(
+    image: Sequence[float],
+    width: int,
+    height: int,
+    channels: int,
+    c_real: float,
+    c_imag: float,
+    max_iter: int = 100,
+) -> RuntimeVisualMetrics: ...
+
 def lobe_point_at_angle(
     period: int, sub_lobe: int, theta: float, s: float = 1.0
 ) -> Complex: ...

--- a/backend/stubs/src/visual_metrics.pyi
+++ b/backend/stubs/src/visual_metrics.pyi
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TypeAlias
 import numpy as np
 
 class LossVisualMetrics:
@@ -10,5 +11,4 @@ class LossVisualMetrics:
         self, image: np.ndarray, prev_image: np.ndarray | None = None
     ) -> dict[str, float]: ...
 
-class VisualMetrics(LossVisualMetrics):
-    ...
+VisualMetrics: TypeAlias = LossVisualMetrics

--- a/backend/stubs/src/visual_metrics.pyi
+++ b/backend/stubs/src/visual_metrics.pyi
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import numpy as np
 
-class VisualMetrics:
+class LossVisualMetrics:
     def __init__(self) -> None: ...
-    def compute_all_metrics(self, image: np.ndarray) -> dict[str, float]: ...
+    def compute_all_metrics(
+        self, image: np.ndarray, prev_image: np.ndarray | None = None
+    ) -> dict[str, float]: ...
+
+class VisualMetrics(LossVisualMetrics):
+    ...

--- a/backend/tests/test_e2e.py
+++ b/backend/tests/test_e2e.py
@@ -46,7 +46,7 @@ def test_imports():
 
         print("✓ control_trainer imports")
 
-        from src.visual_metrics import VisualMetrics  # noqa: F401
+        from src.visual_metrics import LossVisualMetrics  # noqa: F401
 
         print("✓ visual_metrics imports")
 
@@ -200,16 +200,24 @@ def test_visual_metrics():
     print("=" * 60)
     try:
         import numpy as np
-        from src.visual_metrics import VisualMetrics
+        import runtime_core
+        from src.visual_metrics import LossVisualMetrics
 
         # Initialize
-        metrics = VisualMetrics()
-        print("✓ VisualMetrics initialized")
+        metrics = LossVisualMetrics()
+        print("✓ LossVisualMetrics initialized")
 
         # Test with a synthetic image
         test_image = np.random.randint(0, 256, (128, 128, 3), dtype=np.uint8)
         result = metrics.compute_all_metrics(test_image)
-        print(f"✓ Metrics computed: {len(result)} metrics")
+        print(f"✓ Loss metrics computed: {len(result)} metrics")
+
+        image_float = test_image.astype(np.float64) / 255.0
+        flat = image_float.reshape(-1).tolist()
+        runtime_metrics = runtime_core.compute_runtime_visual_metrics(
+            flat, test_image.shape[1], test_image.shape[0], test_image.shape[2], 0.0, 0.0, 50
+        )
+        print(f"✓ Runtime metrics computed: edge_density={runtime_metrics.edge_density:.4f}")
 
         assert isinstance(result, dict), f"Expected dict, got {type(result)}"
         assert len(result) > 0, "Expected at least one metric"

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -121,18 +121,27 @@ def test_visual_metrics():
     print("\n[Test 5] Testing visual metrics...")
     try:
         import numpy as np
-        from src.visual_metrics import VisualMetrics
+        import runtime_core
+        from src.visual_metrics import LossVisualMetrics
 
-        vm = VisualMetrics()
-        print("  ✓ VisualMetrics created")
+        vm = LossVisualMetrics()
+        print("  ✓ LossVisualMetrics created")
 
         # Create a synthetic image
         image = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
 
-        # Compute metrics
+        # Compute loss metrics
         metrics = vm.compute_all_metrics(image)
-        print(f"    - Metrics computed: {len(metrics)} metrics")
-        print(f"    - Edge density: {metrics['edge_density']:.4f}")
+        print(f"    - Loss metrics computed: {len(metrics)} metrics")
+        print(f"    - Temporal change: {metrics['temporal_change']:.4f}")
+
+        # Compute runtime metrics from Rust
+        image_float = image.astype(np.float64) / 255.0
+        flat = image_float.reshape(-1).tolist()
+        runtime_metrics = runtime_core.compute_runtime_visual_metrics(
+            flat, image.shape[1], image.shape[0], image.shape[2], 0.0, 0.0, 50
+        )
+        print(f"    - Edge density: {runtime_metrics.edge_density:.4f}")
 
         return True
     except Exception as e:

--- a/backend/tests/test_visual_metrics.py
+++ b/backend/tests/test_visual_metrics.py
@@ -10,236 +10,75 @@ from pathlib import Path
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.visual_metrics import VisualMetrics  # noqa: E402
+from src.visual_metrics import LossVisualMetrics  # noqa: E402
 
 
-class TestVisualMetrics:
-    """Test visual metrics computation."""
+def _compute_runtime_metrics(runtime_core, image: np.ndarray, c_real: float, c_imag: float):
+    if image.max() > 1.0:
+        image = image.astype(np.float64) / 255.0
+    height, width = image.shape[:2]
+    channels = 1 if image.ndim == 2 else image.shape[2]
+    flat = image.astype(np.float64).reshape(-1).tolist()
+    return runtime_core.compute_runtime_visual_metrics(
+        flat, width, height, channels, c_real, c_imag, 50
+    )
+
+
+class TestLossVisualMetrics:
+    """Test loss-only visual metrics computation."""
 
     def test_metrics_initialization(self):
-        """Test creating VisualMetrics instance."""
-        metrics = VisualMetrics()
+        """Test creating LossVisualMetrics instance."""
+        metrics = LossVisualMetrics()
         assert metrics is not None
-
-    def test_simple_image_metrics(self):
-        """Test computing metrics on a simple synthetic image."""
-        metrics_calc = VisualMetrics()
-
-        # Create a simple gradient image (64x64)
-        image = np.linspace(0, 1, 64 * 64).reshape(64, 64).astype(np.float32)
-
-        results = metrics_calc.compute_all_metrics(image)
-
-        # Check all expected metrics are present
-        assert "edge_density" in results
-        assert "color_uniformity" in results
-        assert "brightness_mean" in results
-        assert "brightness_std" in results
-        assert "brightness_range" in results
-        assert "temporal_change" in results
-        assert "connectedness" in results
-
-        # Check values are in reasonable ranges
-        assert 0.0 <= results["edge_density"] <= 1.0
-        assert 0.0 <= results["color_uniformity"] <= 1.0
-        assert 0.0 <= results["brightness_mean"] <= 1.0
-        assert results["brightness_std"] >= 0.0
-        assert 0.0 <= results["brightness_range"] <= 1.0
-        assert results["temporal_change"] == 0.0  # No previous image
-
-    def test_color_image_metrics(self):
-        """Test computing metrics on RGB color image."""
-        metrics_calc = VisualMetrics()
-
-        # Create a simple color image (64x64x3)
-        image = np.random.rand(64, 64, 3).astype(np.float32)
-
-        results = metrics_calc.compute_all_metrics(image)
-
-        # All metrics should still be computed
-        assert len(results) == 7
-        assert all(isinstance(v, (float, np.floating)) for v in results.values())
-
-    def test_uint8_image_normalization(self):
-        """Test that uint8 images [0,255] are normalized correctly."""
-        metrics_calc = VisualMetrics()
-
-        # Create image in [0, 255] range
-        image_255 = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
-        results_255 = metrics_calc.compute_all_metrics(image_255)
-
-        # Create same image normalized to [0, 1]
-        image_01 = image_255.astype(np.float32) / 255.0
-        results_01 = metrics_calc.compute_all_metrics(image_01)
-
-        # Results should be very similar (allowing for floating point differences)
-        for key in results_255.keys():
-            if key != "temporal_change":  # Skip temporal since no prev image
-                assert (
-                    abs(results_255[key] - results_01[key]) < 0.01
-                ), f"Mismatch for {key}: {results_255[key]} vs {results_01[key]}"
 
     def test_temporal_change(self):
         """Test temporal change metric between frames."""
-        metrics_calc = VisualMetrics()
+        metrics_calc = LossVisualMetrics()
 
-        # Create two slightly different images
         image1 = np.random.rand(64, 64).astype(np.float32)
         image2 = image1 + np.random.randn(64, 64).astype(np.float32) * 0.1
 
         results = metrics_calc.compute_all_metrics(image2, prev_image=image1)
 
-        # Temporal change should be non-zero
+        assert "temporal_change" in results
         assert results["temporal_change"] > 0.0
-        # And should be reasonable (not too large)
         assert results["temporal_change"] < 1.0
-
-    def test_edge_density_extremes(self):
-        """Test edge density on extreme cases."""
-        metrics_calc = VisualMetrics()
-
-        # Uniform image (no edges)
-        uniform = np.ones((64, 64), dtype=np.float32) * 0.5
-        results_uniform = metrics_calc.compute_all_metrics(uniform)
-
-        # High-contrast checkerboard pattern (many edges)
-        # Scale to uint8 range for better edge detection
-        checkerboard = np.zeros((64, 64), dtype=np.uint8)
-        checkerboard[::2, ::2] = 255
-        checkerboard[1::2, 1::2] = 255
-        results_checkerboard = metrics_calc.compute_all_metrics(checkerboard)
-
-        # Checkerboard should have higher edge density than uniform
-        # (or at least equal if edge detector is very conservative)
-        assert results_checkerboard["edge_density"] >= results_uniform["edge_density"]
-
-        # Create a high-contrast gradient (should have some edges)
-        gradient = np.tile(np.linspace(0, 255, 64, dtype=np.uint8), (64, 1))
-        results_gradient = metrics_calc.compute_all_metrics(gradient)
-
-        # Gradient should have non-zero edge density
-        assert results_gradient["edge_density"] >= 0.0  # At least valid
-
-    def test_brightness_metrics(self):
-        """Test brightness statistics are computed correctly."""
-        metrics_calc = VisualMetrics()
-
-        # Dark image
-        dark = np.ones((64, 64), dtype=np.float32) * 0.2
-        results_dark = metrics_calc.compute_all_metrics(dark)
-
-        # Bright image
-        bright = np.ones((64, 64), dtype=np.float32) * 0.8
-        results_bright = metrics_calc.compute_all_metrics(bright)
-
-        # Brightness mean should reflect image brightness
-        assert results_dark["brightness_mean"] < 0.3
-        assert results_bright["brightness_mean"] > 0.7
-
-        # Uniform images should have low std and range
-        assert results_dark["brightness_std"] < 0.01
-        assert results_bright["brightness_std"] < 0.01
-        assert results_dark["brightness_range"] < 0.01
-        assert results_bright["brightness_range"] < 0.01
-
-    def test_color_uniformity(self):
-        """Test color uniformity metric."""
-        metrics_calc = VisualMetrics()
-
-        # Uniform color image
-        uniform_color = np.ones((64, 64, 3), dtype=np.float32) * 0.5
-        results_uniform = metrics_calc.compute_all_metrics(uniform_color)
-
-        # Random color image
-        random_color = np.random.rand(64, 64, 3).astype(np.float32)
-        results_random = metrics_calc.compute_all_metrics(random_color)
-
-        # Uniform should have higher color uniformity than random
-        assert results_uniform["color_uniformity"] > results_random["color_uniformity"]
 
     def test_render_julia_set(self):
         """Test Julia set rendering."""
-        metrics_calc = VisualMetrics()
+        metrics_calc = LossVisualMetrics()
 
-        # Render a Julia set
         image = metrics_calc.render_julia_set(
             seed_real=-0.7, seed_imag=0.27, width=128, height=128, zoom=1.0
         )
 
-        # Check image properties
         assert image.shape == (128, 128, 3)
         assert image.dtype == np.uint8
         assert image.min() >= 0
         assert image.max() <= 255
 
-        # Image should not be all black or all white
-        assert image.mean() > 10
-        assert image.mean() < 245
 
-    def test_render_julia_set_different_seeds(self):
-        """Test that different Julia seeds produce different images."""
-        metrics_calc = VisualMetrics()
+class TestRuntimeVisualMetrics:
+    """Test Rust-backed runtime visual metrics."""
 
-        # Render two Julia sets with different seeds
-        image1 = metrics_calc.render_julia_set(-0.7, 0.27, 64, 64, 1.0)
-        image2 = metrics_calc.render_julia_set(-0.4, 0.6, 64, 64, 1.0)
+    def test_runtime_metrics_ranges(self, runtime_core_module):
+        """Ensure runtime metrics are computed and within expected ranges."""
+        image = np.random.rand(32, 32, 3).astype(np.float32)
+        metrics = _compute_runtime_metrics(runtime_core_module, image, 0.0, 0.0)
 
-        # Images should be different
-        diff = np.abs(image1.astype(float) - image2.astype(float)).mean()
-        assert diff > 1.0  # Should have noticeable difference
+        assert 0.0 <= metrics.edge_density <= 1.0
+        assert 0.0 <= metrics.color_uniformity <= 1.0
+        assert 0.0 <= metrics.brightness_mean <= 1.0
+        assert metrics.brightness_std >= 0.0
+        assert 0.0 <= metrics.brightness_range <= 1.0
+        assert metrics.mandelbrot_membership is True
 
-    def test_render_julia_set_zoom(self):
-        """Test Julia set rendering with different zoom levels."""
-        metrics_calc = VisualMetrics()
-
-        # Render at different zoom levels
-        image_zoom_out = metrics_calc.render_julia_set(-0.7, 0.27, 64, 64, zoom=0.5)
-        image_zoom_in = metrics_calc.render_julia_set(-0.7, 0.27, 64, 64, zoom=2.0)
-
-        # Both should be valid images
-        assert image_zoom_out.shape == (64, 64, 3)
-        assert image_zoom_in.shape == (64, 64, 3)
-
-        # Images should be different due to zoom
-        diff = np.abs(image_zoom_out.astype(float) - image_zoom_in.astype(float)).mean()
-        assert diff > 1.0
-
-    def test_metrics_are_finite(self):
-        """Test that all metrics are finite numbers (no NaN or Inf)."""
-        metrics_calc = VisualMetrics()
-
-        # Test with various edge cases
-        test_images = [
-            np.zeros((64, 64), dtype=np.float32),  # All black
-            np.ones((64, 64), dtype=np.float32),  # All white
-            np.random.rand(64, 64).astype(np.float32),  # Random
-            np.eye(64, dtype=np.float32),  # Diagonal
-        ]
-
-        for i, image in enumerate(test_images):
-            results = metrics_calc.compute_all_metrics(image)
-            for key, value in results.items():
-                assert np.isfinite(
-                    value
-                ), f"Non-finite value for {key} in test image {i}: {value}"
-
-    def test_batch_consistency(self):
-        """Test that metrics are consistent when computed multiple times."""
-        metrics_calc = VisualMetrics()
-
-        # Create a fixed image
-        np.random.seed(42)
-        image = np.random.rand(64, 64).astype(np.float32)
-
-        # Compute metrics multiple times
-        results1 = metrics_calc.compute_all_metrics(image)
-        results2 = metrics_calc.compute_all_metrics(image)
-
-        # Results should be numerically identical (within floating-point tolerance)
-        for key in results1.keys():
-            assert np.isclose(
-                results1[key], results2[key], atol=1e-10
-            ), f"Inconsistent results for {key}: {results1[key]} vs {results2[key]}"
+    def test_mandelbrot_membership_outside(self, runtime_core_module):
+        """Ensure membership returns False for an escaping point."""
+        image = np.zeros((8, 8), dtype=np.float32)
+        metrics = _compute_runtime_metrics(runtime_core_module, image, 2.0, 0.0)
+        assert metrics.mandelbrot_membership is False
 
 
 if __name__ == "__main__":

--- a/backend/train.py
+++ b/backend/train.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.data_loader import AudioDataset  # noqa: E402
 from src.control_model import AudioToControlModel  # noqa: E402
 from src.control_trainer import ControlTrainer  # noqa: E402
-from src.visual_metrics import VisualMetrics  # noqa: E402
+from src.visual_metrics import LossVisualMetrics  # noqa: E402
 from src.export_model import export_to_onnx  # noqa: E402
 from src.runtime_core_bridge import make_feature_extractor  # noqa: E402
 
@@ -180,7 +180,7 @@ def main():
     print(f"Found {len(dataset)} audio files")
 
     print("[3/7] Initializing visual metrics...")
-    visual_metrics = VisualMetrics()
+    visual_metrics = LossVisualMetrics()
 
     print("[4/7] Initializing GPU renderer (if enabled)...")
     julia_renderer = None

--- a/runtime-core/src/lib.rs
+++ b/runtime-core/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod geometry;
 pub mod controller;
 pub mod features;
+pub mod visual_metrics;
 
 // Conditional bindings.  Only compile the Python or WASM API if the
 // corresponding feature flag has been enabled.

--- a/runtime-core/src/visual_metrics.rs
+++ b/runtime-core/src/visual_metrics.rs
@@ -1,0 +1,204 @@
+//! Visual metrics computed in Rust for runtime feedback.
+//!
+//! These metrics are intended to feed controller/guardrail logic rather than
+//! loss-only training objectives. They operate on rendered Julia images and
+//! Mandelbrot critical-orbit membership.
+
+use crate::geometry::Complex;
+
+#[derive(Clone, Debug)]
+pub struct RuntimeVisualMetrics {
+    pub edge_density: f64,
+    pub color_uniformity: f64,
+    pub brightness_mean: f64,
+    pub brightness_std: f64,
+    pub brightness_range: f64,
+    pub mandelbrot_membership: bool,
+}
+
+fn clamp_index(value: isize, max: usize) -> usize {
+    if value < 0 {
+        0
+    } else if value as usize >= max {
+        max.saturating_sub(1)
+    } else {
+        value as usize
+    }
+}
+
+fn to_gray(image: &[f64], width: usize, height: usize, channels: usize) -> Vec<f64> {
+    let mut gray = vec![0.0; width * height];
+    if channels == 0 {
+        return gray;
+    }
+    for y in 0..height {
+        for x in 0..width {
+            let base = (y * width + x) * channels;
+            let value = if channels == 1 {
+                image.get(base).copied().unwrap_or(0.0)
+            } else {
+                let r = image.get(base).copied().unwrap_or(0.0);
+                let g = image.get(base + 1).copied().unwrap_or(0.0);
+                let b = image.get(base + 2).copied().unwrap_or(0.0);
+                (r + g + b) / 3.0
+            };
+            gray[y * width + x] = value.clamp(0.0, 1.0);
+        }
+    }
+    gray
+}
+
+fn compute_brightness_stats(gray: &[f64]) -> (f64, f64, f64) {
+    if gray.is_empty() {
+        return (0.0, 0.0, 0.0);
+    }
+    let mut sum = 0.0;
+    let mut min_val = f64::INFINITY;
+    let mut max_val = f64::NEG_INFINITY;
+    for &v in gray {
+        sum += v;
+        if v < min_val {
+            min_val = v;
+        }
+        if v > max_val {
+            max_val = v;
+        }
+    }
+    let mean = sum / gray.len() as f64;
+    let mut var_sum = 0.0;
+    for &v in gray {
+        let delta = v - mean;
+        var_sum += delta * delta;
+    }
+    let std = (var_sum / gray.len() as f64).sqrt();
+    let range = (max_val - min_val).max(0.0);
+    (mean, std, range)
+}
+
+fn compute_edge_density(gray: &[f64], width: usize, height: usize) -> f64 {
+    if gray.is_empty() || width == 0 || height == 0 {
+        return 0.0;
+    }
+    let mut edge_count = 0usize;
+    let threshold = 50.0;
+    for y in 0..height {
+        for x in 0..width {
+            let mut gx = 0.0;
+            let mut gy = 0.0;
+            for ky in -1..=1 {
+                for kx in -1..=1 {
+                    let sample_x = clamp_index(x as isize + kx, width);
+                    let sample_y = clamp_index(y as isize + ky, height);
+                    let value = gray[sample_y * width + sample_x] * 255.0;
+                    let weight_x = match (ky, kx) {
+                        (-1, -1) | (1, -1) => -1.0,
+                        (-1, 1) | (1, 1) => 1.0,
+                        (0, -1) => -2.0,
+                        (0, 1) => 2.0,
+                        _ => 0.0,
+                    };
+                    let weight_y = match (ky, kx) {
+                        (-1, -1) | (-1, 1) => -1.0,
+                        (1, -1) | (1, 1) => 1.0,
+                        (-1, 0) => -2.0,
+                        (1, 0) => 2.0,
+                        _ => 0.0,
+                    };
+                    gx += value * weight_x;
+                    gy += value * weight_y;
+                }
+            }
+            let magnitude = (gx * gx + gy * gy).sqrt();
+            if magnitude >= threshold {
+                edge_count += 1;
+            }
+        }
+    }
+    edge_count as f64 / (width * height) as f64
+}
+
+fn compute_color_uniformity(gray: &[f64], width: usize, height: usize) -> f64 {
+    if gray.is_empty() || width == 0 || height == 0 {
+        return 0.0;
+    }
+    let kernel_radius = 2isize;
+    let kernel_size = 5usize;
+    let kernel_area = (kernel_size * kernel_size) as f64;
+    let mut variance_sum = 0.0;
+
+    for y in 0..height {
+        for x in 0..width {
+            let mut local_sum = 0.0;
+            let mut local_sq_sum = 0.0;
+            for ky in -kernel_radius..=kernel_radius {
+                for kx in -kernel_radius..=kernel_radius {
+                    let sample_x = clamp_index(x as isize + kx, width);
+                    let sample_y = clamp_index(y as isize + ky, height);
+                    let value = gray[sample_y * width + sample_x];
+                    local_sum += value;
+                    local_sq_sum += value * value;
+                }
+            }
+            let mean = local_sum / kernel_area;
+            let variance = (local_sq_sum / kernel_area) - mean * mean;
+            variance_sum += variance.max(0.0);
+        }
+    }
+
+    let avg_variance = variance_sum / (width * height) as f64;
+    (1.0 / (1.0 + avg_variance * 10.0)).clamp(0.0, 1.0)
+}
+
+pub fn mandelbrot_membership(c: Complex, max_iter: usize) -> bool {
+    let mut z = Complex::new(0.0, 0.0);
+    for _ in 0..max_iter {
+        if z.real * z.real + z.imag * z.imag > 4.0 {
+            return false;
+        }
+        z = z * z + c;
+    }
+    true
+}
+
+pub fn compute_runtime_metrics(
+    image: &[f64],
+    width: usize,
+    height: usize,
+    channels: usize,
+    c: Complex,
+    max_iter: usize,
+) -> Result<RuntimeVisualMetrics, &'static str> {
+    if width == 0 || height == 0 {
+        return Err("width and height must be non-zero");
+    }
+    let expected_len = width * height * channels.max(1);
+    if image.len() < expected_len {
+        return Err("image buffer is smaller than expected");
+    }
+
+    let gray = to_gray(image, width, height, channels);
+    let edge_density = compute_edge_density(&gray, width, height);
+    let color_uniformity = compute_color_uniformity(&gray, width, height);
+    let (brightness_mean, brightness_std, brightness_range) = compute_brightness_stats(&gray);
+    let membership = mandelbrot_membership(c, max_iter);
+
+    Ok(RuntimeVisualMetrics {
+        edge_density,
+        color_uniformity,
+        brightness_mean,
+        brightness_std,
+        brightness_range,
+        mandelbrot_membership: membership,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mandelbrot_membership_detects_inside_outside() {
+        assert!(mandelbrot_membership(Complex::new(0.0, 0.0), 50));
+        assert!(!mandelbrot_membership(Complex::new(2.0, 0.0), 10));
+    }
+}


### PR DESCRIPTION
### Motivation
- Separate visual metrics into loss-facing metrics computed in Python and runtime/feedback metrics computed in Rust to make Rust the source-of-truth for controller inputs.
- Replace the previous connected-components heuristic with a Mandelbrot critical-orbit membership predicate (`mandelbrot_membership`) to determine set membership consistently.
- Reduce Python `backend/src/visual_metrics.py` to only loss metrics used in training (temporal change), and surface runtime metrics from `runtime-core` to the backend and frontend.

### Description
- Added `runtime-core/src/visual_metrics.rs` implementing `RuntimeVisualMetrics` with `edge_density`, `color_uniformity`, brightness stats, and `mandelbrot_membership(c, N)`, plus `compute_runtime_metrics` to compute them from an image buffer.
- Exposed the new API from Rust to Python and WASM via `pybindings.rs` (`compute_runtime_visual_metrics` and `RuntimeVisualMetrics`) and `wasm_bindings.rs` respectively, and registered the module in `runtime-core/src/lib.rs`.
- Refactored `backend/src/visual_metrics.py` into `LossVisualMetrics` (loss-only metrics: `temporal_change` and `render_julia_set`) and left `VisualMetrics` as a backwards-compatible alias; updated `backend/src/control_trainer.py`, `backend/train.py`, and examples to use `LossVisualMetrics`.
- Updated Python stubs (`backend/stubs/...`) and tests to call the Rust runtime API where appropriate and adjusted integration/e2e tests to demonstrate runtime metric usage.

### Testing
- Ran `cargo test -p runtime_core --lib`, which completed successfully with the runtime-core unit tests (including the new `mandelbrot_membership` test) passing.  
- Python test suite (`pytest`) was not executed in this change; tests were updated to rely on the new Rust API and will run in CI where the `runtime_core` PyO3 extension is built.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aacddbf448329b0d581d504035aec)