### PR TITLE
Add slow-clock state bus (runtime-core) and frontend bridge

### DIFF
--- a/frontend/src/components/AudioCapture.tsx
+++ b/frontend/src/components/AudioCapture.tsx
@@ -4,19 +4,31 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { AudioFeatureExtractor } from '../lib/audioFeatures';
+import type { SlowState } from '../lib/slowState';
+
+const USE_JS_FEATURES = false;
+const HOP_SIZE = 1024;
+const WINDOW_FRAMES = 10;
+
+type RuntimeCoreBridge = {
+  pushHop: (hop: Float32Array) => SlowState;
+};
 
 interface AudioCaptureProps {
-  onFeatures: (features: number[]) => void;
+  onSlowState: (state: SlowState) => void;
   enabled: boolean;
   audioFile?: File | null;
 }
 
-export function AudioCapture({ onFeatures, enabled, audioFile }: AudioCaptureProps) {
+export function AudioCapture({ onSlowState, enabled, audioFile }: AudioCaptureProps) {
   const [isCapturing, setIsCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const featureExtractorRef = useRef<AudioFeatureExtractor | null>(null);
+  const bridgeRef = useRef<RuntimeCoreBridge | null>(null);
+  const latestSlowStateRef = useRef<SlowState | null>(null);
+  const lastFrameTimeRef = useRef<number | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const audioElementRef = useRef<HTMLAudioElement | null>(null);
@@ -72,9 +84,12 @@ export function AudioCapture({ onFeatures, enabled, audioFile }: AudioCapturePro
       source.connect(analyser);
       analyser.connect(audioContext.destination); // Connect to speakers
 
-      // Create feature extractor
-      const featureExtractor = new AudioFeatureExtractor(audioContext, analyser);
-      featureExtractorRef.current = featureExtractor;
+      if (USE_JS_FEATURES) {
+        const featureExtractor = new AudioFeatureExtractor(audioContext, analyser);
+        featureExtractorRef.current = featureExtractor;
+      }
+
+      bridgeRef.current = createMockRuntimeCoreBridge(audioContext.sampleRate);
 
       // Start playback
       await audio.play();
@@ -82,17 +97,7 @@ export function AudioCapture({ onFeatures, enabled, audioFile }: AudioCapturePro
       setIsCapturing(true);
       setError(null);
 
-      // Start feature extraction loop
-      const extractLoop = () => {
-        if (!featureExtractorRef.current) return;
-
-        const features = featureExtractorRef.current.extractWindowedFeatures(10);
-        onFeatures(features);
-
-        animationFrameRef.current = requestAnimationFrame(extractLoop);
-      };
-
-      extractLoop();
+      startLoops();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load audio file';
       setError(errorMessage);
@@ -112,30 +117,25 @@ export function AudioCapture({ onFeatures, enabled, audioFile }: AudioCapturePro
 
       // Create analyser node
       const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.8;
       analyserRef.current = analyser;
 
       // Connect microphone to analyser
       const source = audioContext.createMediaStreamSource(stream);
       source.connect(analyser);
 
-      // Create feature extractor
-      const featureExtractor = new AudioFeatureExtractor(audioContext, analyser);
-      featureExtractorRef.current = featureExtractor;
+      if (USE_JS_FEATURES) {
+        const featureExtractor = new AudioFeatureExtractor(audioContext, analyser);
+        featureExtractorRef.current = featureExtractor;
+      }
+
+      bridgeRef.current = createMockRuntimeCoreBridge(audioContext.sampleRate);
 
       setIsCapturing(true);
       setError(null);
 
-      // Start feature extraction loop
-      const extractLoop = () => {
-        if (!featureExtractorRef.current) return;
-
-        const features = featureExtractorRef.current.extractWindowedFeatures(10);
-        onFeatures(features);
-
-        animationFrameRef.current = requestAnimationFrame(extractLoop);
-      };
-
-      extractLoop();
+      startLoops();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to access microphone';
       setError(errorMessage);
@@ -171,7 +171,93 @@ export function AudioCapture({ onFeatures, enabled, audioFile }: AudioCapturePro
 
     analyserRef.current = null;
     featureExtractorRef.current = null;
+    bridgeRef.current = null;
+    latestSlowStateRef.current = null;
+    lastFrameTimeRef.current = null;
     setIsCapturing(false);
+  };
+
+  const startLoops = () => {
+    const processLoop = (timestamp: number) => {
+      const analyser = analyserRef.current;
+      const bridge = bridgeRef.current;
+      if (!analyser || !bridge) {
+        return;
+      }
+
+      const timeData = new Float32Array(analyser.fftSize);
+      analyser.getFloatTimeDomainData(timeData);
+      const hop = timeData.slice(0, HOP_SIZE);
+      let slowState = bridge.pushHop(hop);
+
+      if (USE_JS_FEATURES && featureExtractorRef.current) {
+        slowState = {
+          ...slowState,
+          features: featureExtractorRef.current.extractWindowedFeatures(WINDOW_FRAMES),
+        };
+      }
+
+      latestSlowStateRef.current = slowState;
+      const latestState = latestSlowStateRef.current;
+
+      const lastFrameTime = lastFrameTimeRef.current ?? timestamp;
+      const dt = (timestamp - lastFrameTime) / 1000;
+      lastFrameTimeRef.current = timestamp;
+
+      if (latestState) {
+        const predicted = predictFastPhase(latestState, dt);
+        onSlowState(predicted);
+      }
+
+      animationFrameRef.current = requestAnimationFrame(processLoop);
+    };
+
+    animationFrameRef.current = requestAnimationFrame(processLoop);
+  };
+
+  const predictFastPhase = (slowState: SlowState, dt: number): SlowState => {
+    const { beat } = slowState;
+    const phaseAdvance = dt / beat.spb;
+    const phase = (beat.phase + phaseAdvance) % 1;
+    return {
+      ...slowState,
+      beat: {
+        ...beat,
+        phase,
+      },
+    };
+  };
+
+  const createMockRuntimeCoreBridge = (sampleRate: number): RuntimeCoreBridge => {
+    let tSec = 0;
+    let phase = 0;
+    let beatCount = 0;
+    const spb = 0.5;
+    const structure = { section_probs: [0, 0, 0, 0], hazard_probs: [0, 0, 0, 0] };
+    return {
+      pushHop: (hop: Float32Array) => {
+        const dt = hop.length / sampleRate;
+        tSec += dt;
+        const phaseAdvance = dt / spb;
+        const nextPhase = phase + phaseAdvance;
+        const beatsCrossed = Math.floor(nextPhase);
+        phase = ((nextPhase % 1) + 1) % 1;
+        if (beatsCrossed > 0) {
+          beatCount += beatsCrossed;
+        }
+        return {
+          beat: {
+            t_sec: tSec,
+            spb,
+            phase,
+            beat_count: beatCount,
+            conf: 0.5,
+          },
+          structure,
+          features: [],
+        };
+      },
+    };
   };
 
   if (error) {

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import { JuliaRenderer, VisualParameters } from '../lib/juliaRenderer';
 import { ModelInference, PerformanceMetrics, ModelMetadata } from '../lib/modelInference';
 import { AudioCapture } from './AudioCapture';
+import type { SlowState } from '../lib/slowState';
 import { FullscreenToggle } from './FullscreenToggle';
 
 export function Visualizer() {
@@ -119,13 +120,13 @@ export function Visualizer() {
     loadModel();
   }, []);
 
-  const handleFeatures = async (features: number[]) => {
+  const handleSlowState = async (state: SlowState) => {
     if (!rendererRef.current) return;
 
     try {
-      if (modelRef.current && modelRef.current.isLoaded()) {
+      if (modelRef.current && modelRef.current.isLoaded() && state.features.length > 0) {
         // Run inference with the model
-        const params = await modelRef.current.infer(features);
+        const params = await modelRef.current.infer(state.features);
         
         // Update metrics display
         const modelMetrics = modelRef.current.getMetrics();
@@ -476,7 +477,7 @@ export function Visualizer() {
       </div>
 
       {isVisualizing && (
-        <AudioCapture onFeatures={handleFeatures} enabled={isVisualizing} audioFile={audioFile} />
+        <AudioCapture onSlowState={handleSlowState} enabled={isVisualizing} audioFile={audioFile} />
       )}
     </div>
   );

--- a/frontend/src/lib/slowState.ts
+++ b/frontend/src/lib/slowState.ts
@@ -1,0 +1,18 @@
+export type BeatClockState = {
+  t_sec: number;
+  spb: number;
+  phase: number;
+  beat_count: number;
+  conf: number;
+};
+
+export type StructureState = {
+  section_probs: number[];
+  hazard_probs: number[];
+};
+
+export type SlowState = {
+  beat: BeatClockState;
+  structure: StructureState;
+  features: number[];
+};

--- a/runtime-core/src/clock.rs
+++ b/runtime-core/src/clock.rs
@@ -1,0 +1,113 @@
+//! Slow-clock audio state bus.
+//!
+//! This module defines the low-frequency (hop-rate) state that is treated as
+//! the source of truth for timing, beat tracking, and structure inference.
+
+use serde::{Deserialize, Serialize};
+
+use crate::features::FeatureExtractor;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BeatClockState {
+    pub t_sec: f32,
+    pub spb: f32,
+    pub phase: f32,
+    pub beat_count: i64,
+    pub conf: f32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StructureState {
+    pub section_probs: Vec<f32>,
+    pub hazard_probs: Vec<f32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SlowState {
+    pub beat: BeatClockState,
+    pub structure: StructureState,
+    pub features: Vec<f32>,
+}
+
+pub struct SlowClock {
+    sr: f32,
+    hop_size: usize,
+    feature_extractor: FeatureExtractor,
+    beat: BeatClockState,
+    structure: StructureState,
+}
+
+impl SlowClock {
+    pub fn new() -> Self {
+        let feature_extractor = FeatureExtractor::default();
+        let beat = BeatClockState {
+            t_sec: 0.0,
+            spb: 0.5,
+            phase: 0.0,
+            beat_count: 0,
+            conf: 0.5,
+        };
+        let structure = StructureState {
+            section_probs: vec![0.0; 4],
+            hazard_probs: vec![0.0; 4],
+        };
+        Self {
+            sr: feature_extractor.sr as f32,
+            hop_size: feature_extractor.hop_length,
+            feature_extractor,
+            beat,
+            structure,
+        }
+    }
+
+    pub fn process_hop(&mut self, hop: &[f32]) -> SlowState {
+        let dt = self.hop_size as f32 / self.sr;
+        self.beat.t_sec += dt;
+        let phase = self.beat.phase + dt / self.beat.spb;
+        let beats_crossed = phase.floor() as i64;
+        self.beat.phase = phase.rem_euclid(1.0);
+        if beats_crossed > 0 {
+            self.beat.beat_count += beats_crossed;
+        }
+
+        let features = self
+            .feature_extractor
+            .extract_features(hop)
+            .iter()
+            .map(|series| series.first().copied().unwrap_or(0.0) as f32)
+            .collect::<Vec<f32>>();
+
+        SlowState {
+            beat: self.beat.clone(),
+            structure: self.structure.clone(),
+            features,
+        }
+    }
+}
+
+pub struct SlowStateStream {
+    clock: SlowClock,
+}
+
+impl SlowStateStream {
+    pub fn new() -> Self {
+        Self {
+            clock: SlowClock::new(),
+        }
+    }
+
+    pub fn process_hop(&mut self, hop: &[f32]) -> SlowState {
+        self.clock.process_hop(hop)
+    }
+
+    pub fn process_hop_json(&mut self, hop: &[f32]) -> serde_json::Result<String> {
+        let state = self.clock.process_hop(hop);
+        serde_json::to_string(&state)
+    }
+
+    pub fn process_hop_ndjson(&mut self, hop: &[f32]) -> serde_json::Result<String> {
+        let mut json = self.process_hop_json(hop)?;
+        json.push('\n');
+        Ok(json)
+    }
+}

--- a/runtime-core/src/lib.rs
+++ b/runtime-core/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod geometry;
 pub mod controller;
 pub mod features;
+pub mod clock;
 pub mod visual_metrics;
 pub mod distance_field;
 

--- a/runtime-core/tests/slow_clock_tests.rs
+++ b/runtime-core/tests/slow_clock_tests.rs
@@ -1,0 +1,52 @@
+use runtime_core::clock::{SlowClock, SlowState};
+
+fn approx_eq(a: f32, b: f32, eps: f32) -> bool {
+    (a - b).abs() <= eps
+}
+
+#[test]
+fn slow_clock_time_advances() {
+    let mut clock = SlowClock::new();
+    let hop = vec![0.0_f32; 1024];
+    let mut state = clock.process_hop(&hop);
+    let dt = 1024.0 / 48_000.0;
+    assert!(approx_eq(state.beat.t_sec, dt, 1e-6));
+
+    for _ in 0..9 {
+        state = clock.process_hop(&hop);
+    }
+
+    assert!(approx_eq(state.beat.t_sec, dt * 10.0, 1e-6));
+}
+
+#[test]
+fn slow_clock_phase_wraps() {
+    let mut clock = SlowClock::new();
+    let hop = vec![0.0_f32; 1024];
+    let dt = 1024.0 / 48_000.0;
+    let spb = 0.5;
+
+    let mut state = clock.process_hop(&hop);
+    let mut expected_phase = (dt / spb) % 1.0;
+    assert!(approx_eq(state.beat.phase, expected_phase, 1e-6));
+    assert!(state.beat.phase >= 0.0 && state.beat.phase < 1.0);
+
+    for _ in 0..9 {
+        state = clock.process_hop(&hop);
+    }
+
+    expected_phase = (dt * 10.0 / spb) % 1.0;
+    assert!(approx_eq(state.beat.phase, expected_phase, 1e-6));
+    assert!(state.beat.phase >= 0.0 && state.beat.phase < 1.0);
+}
+
+#[test]
+fn slow_state_roundtrip_json() {
+    let mut clock = SlowClock::new();
+    let hop = vec![0.0_f32; 1024];
+    let state = clock.process_hop(&hop);
+    let json = serde_json::to_string(&state).expect("serialize");
+    let decoded: SlowState = serde_json::from_str(&json).expect("deserialize");
+    assert!(approx_eq(state.beat.t_sec, decoded.beat.t_sec, 1e-6));
+    assert_eq!(state.features.len(), decoded.features.len());
+}


### PR DESCRIPTION
### Motivation
- Make `runtime-core` the single source of truth for audio timing and analysis by adding a hop-rate slow clock and state bus that the frontend consumes. 
- Provide a stable `SlowState` shape (including a placeholder `BeatClockState`) to prepare for future BeatNet integration and avoid duplicating tempo/beat logic in the frontend. 

### Description
- Added a new Rust module `runtime-core/src/clock.rs` defining `BeatClockState`, `StructureState`, `SlowState`, `SlowClock`, and `SlowStateStream` with `process_hop`, `process_hop_json`, and `process_hop_ndjson` helpers, and deterministic hop-based time/phase advancement. 
- Wired the module into the crate by exporting `clock` from `runtime-core/src/lib.rs`. 
- Implemented `process_hop` to advance `t_sec` by `hop/sr`, update beat `phase` and `beat_count` predictively from `spb`, and extract a representative feature frame via the existing `FeatureExtractor`. 
- Added unit tests `runtime-core/tests/slow_clock_tests.rs` that verify time advances after N hops, phase remains in `[0,1)` and advances proportional to `dt/spb`, and `SlowState` is JSON-serializable (serde round-trip). 
- Frontend changes include `frontend/src/lib/slowState.ts` type definitions mirroring the Rust structs and a refactor of `frontend/src/components/AudioCapture.tsx` to send raw PCM hops to a runtime-core bridge (currently a mock `pushHop` implementation), store the latest `SlowState`, and provide a fast-clock predictive phase interpolation at render rate; the old JS feature extraction is kept behind a `USE_JS_FEATURES` flag for debugging. 
- Updated `frontend/src/components/Visualizer.tsx` to consume `SlowState` from the audio capture component and to run inference only when `state.features` is present. 

### Testing
- Ran `cargo test -p runtime_core` and all unit tests passed, including the new slow-clock tests (`slow_clock_time_advances`, `slow_clock_phase_wraps`, `slow_state_roundtrip_json`).
- Built the frontend (`tsc && vite build`) via `npm --prefix frontend run build` and the TypeScript build and production bundle completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de9175c4c83299a2a7cbef20b43ba)