### PR TITLE
Add server-side telemetry logging and diagnostics

### DIFF
--- a/backend/tests/test_api_telemetry.py
+++ b/backend/tests/test_api_telemetry.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+from api.server import app
+import json
+
+
+def test_ping():
+    client = TestClient(app)
+    resp = client.get("/api/ping")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("ok") is True
+    assert "cwd" in data
+
+
+def test_post_telemetry_creates_log(tmp_path, monkeypatch):
+    # Run the server inside a temp working directory so logs are written to tmp_path / logs
+    monkeypatch.chdir(tmp_path)
+
+    client = TestClient(app)
+
+    payload = {"dx": 0.1, "dy": -0.02, "note": "test"}
+    resp = client.post("/api/telemetry", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ok"
+
+    log = tmp_path / "logs" / "telemetry.log"
+    assert log.exists()
+    text = log.read_text(encoding="utf-8")
+    lines = [line for line in text.splitlines() if line.strip()]
+    assert len(lines) == 1
+
+    entry = json.loads(lines[0])
+    assert entry["payload"] == payload
+    assert entry["ts"].endswith("Z")
+
+    # Test the GET helper that returns last N lines
+    resp2 = client.get("/api/telemetry/last?n=10")
+    assert resp2.status_code == 200
+    data = resp2.json()
+    assert data["count"] == 1
+    assert data["entries"][0]["payload"] == payload

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -23,6 +23,7 @@ export function Visualizer() {
   const [inferenceFailures, setInferenceFailures] = useState(0);
   const [audioFile, setAudioFile] = useState<File | null>(null);
   const [audioReactiveEnabled, setAudioReactiveEnabled] = useState(false);
+  const [telemetryEnabled, setTelemetryEnabled] = useState(false);
   const [gradMode, setGradMode] = useState<'off' | 'cheap' | 'full'>('full');
   const metricsUpdateRef = useRef<number | null>(null);
 
@@ -391,6 +392,30 @@ export function Visualizer() {
             title="Toggle audio-reactive post-processing (MR #8 / commit 75c1a43)"
           >
             Audio-Reactive: {audioReactiveEnabled ? 'ON' : 'OFF'}
+          </button>
+
+          <button
+            onClick={() => {
+              const next = !telemetryEnabled;
+              setTelemetryEnabled(next);
+              if (modelRef.current) {
+                (modelRef.current as any).setTelemetryEnabled(next);
+                (modelRef.current as any).__telemetryEnabled = next;
+              }
+            }}
+            style={{
+              padding: '5px 10px',
+              background: telemetryEnabled ? '#4CAF50' : '#222',
+              color: '#fff',
+              border: '1px solid #888',
+              borderRadius: '3px',
+              cursor: 'pointer',
+              fontSize: '12px',
+              marginLeft: '10px'
+            }}
+            title="Toggle server-side telemetry logging"
+          >
+            Telemetry: {telemetryEnabled ? 'ON' : 'OFF'}
           </button>
         </div>
 

--- a/frontend/src/lib/modelInference.ts
+++ b/frontend/src/lib/modelInference.ts
@@ -70,6 +70,43 @@ export class ModelInference {
     postProcessingTime: 0
   };
 
+  // Telemetry: if enabled, we will POST aggregated telemetry to the local backend
+  private telemetryEnabled: boolean = false;
+  private telemetryCounter: number = 0;
+
+  /**
+   * Enable or disable server-side telemetry logging. When enabled, the frontend will
+   * periodically post compact telemetry JSON to POST /api/telemetry.
+   */
+  setTelemetryEnabled(enabled: boolean): void {
+    this.telemetryEnabled = enabled;
+    console.log(`[ModelInference] telemetry ${enabled ? 'enabled' : 'disabled'}`);
+
+    // Send an immediate ping to verify connectivity when enabling telemetry
+    if (enabled) {
+      try {
+        const payload = { type: 'ping', ts: new Date().toISOString(), model_type: this.metadata?.model_type ?? null };
+        void this.sendTelemetry(payload);
+        console.debug('[ModelInference] Sent telemetry ping', payload);
+      } catch (e) {
+        console.warn('[ModelInference] telemetry ping failed', e);
+      }
+    }
+  }
+
+  private async sendTelemetry(payload: any): Promise<void> {
+    if (typeof fetch === 'undefined') return;
+    try {
+      await fetch('/api/telemetry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } catch (e) {
+      console.warn('[ModelInference] telemetry send failed', e);
+    }
+  }
+
   /**
    * Enable or disable audio-reactive post-processing (MR #8 / commit 75c1a43).
    * When enabled, mixes model outputs with raw audio features for dynamic visuals.
@@ -257,6 +294,8 @@ export class ModelInference {
       }
       avgRMS /= windowFrames;
       avgOnset /= windowFrames;
+      // Expose a telemetry-friendly value for logging
+      (this as any)._lastAvgRMS = avgRMS;
 
       // Map to visual parameters
       const currentHue = (avgRMS * 2.0) % 1.0;
@@ -310,6 +349,8 @@ export class ModelInference {
         avgZCR /= windowFrames;
         avgOnset /= windowFrames;
         avgRolloff /= windowFrames;
+        // Expose for telemetry
+        (this as any)._lastAvgRMS = avgRMS;
         
         // Color: Map RMS (loudness) to hue cycling, onset to saturation
         visualParams.colorHue = (params[2] + avgRMS * 2.0) % 1.0;
@@ -359,6 +400,20 @@ export class ModelInference {
         speed: visualParams.speed.toFixed(3),
         modelType: this.isOrbitModel ? 'orbit_control' : 'legacy'
       });
+
+      // If telemetry is enabled, periodically POST a compact record to the backend
+      if (this.telemetryEnabled) {
+        this.telemetryCounter += 1;
+        if (this.telemetryCounter % 30 === 0) { // ~0.5s at 60fps
+          try {
+            const payload = this.assembleTelemetryEntry(params);
+            // Fire-and-forget; failures are non-fatal
+            void this.sendTelemetry(payload);
+          } catch (e) {
+            console.warn('[ModelInference] telemetry assembly failed', e);
+          }
+        }
+      }
     }
 
     return visualParams;
@@ -376,6 +431,84 @@ export class ModelInference {
    */
   getMetadata(): ModelMetadata | null {
     return this.metadata;
+  }
+
+  /**
+   * Assemble a compact telemetry payload including model proposals and minimap context.
+   * This is public to make it testable.
+   */
+  assembleTelemetryEntry(params: number[]): Record<string, any> {
+    const model_dx = (params.length > 0 ? params[0] : 0);
+    const model_dy = (params.length > 1 ? params[1] : 0);
+
+    // Base applied delta from state
+    const applied_delta = Math.hypot(this.stepState?.prev_delta_real ?? 0, this.stepState?.prev_delta_imag ?? 0) || 0;
+
+    // Attempt to extract minimap context if available
+    let c_real: number | null = this.stepState?.c_real ?? null;
+    let c_imag: number | null = this.stepState?.c_imag ?? null;
+    let prev_dx: number | null = this.stepState?.prev_delta_real ?? null;
+    let prev_dy: number | null = this.stepState?.prev_delta_imag ?? null;
+    let nu_norm: number | null = null;
+    let membership: number | null = null;
+    let grad_re: number | null = null;
+    let grad_im: number | null = null;
+    let sensitivity: number | null = null;
+    let patch_mean: number | null = null;
+    let patch_max: number | null = null;
+
+    if (this.stepController && this.stepState && typeof (this.stepController as any).context === 'function') {
+      try {
+        const ctx = (this.stepController as any).context(this.stepState);
+        if (ctx && Array.isArray(ctx.feature_vec) && ctx.feature_vec.length >= 9) {
+          const fv: number[] = ctx.feature_vec;
+          c_real = typeof fv[0] === 'number' ? fv[0] : c_real;
+          c_imag = typeof fv[1] === 'number' ? fv[1] : c_imag;
+          prev_dx = typeof fv[2] === 'number' ? fv[2] : prev_dx;
+          prev_dy = typeof fv[3] === 'number' ? fv[3] : prev_dy;
+          nu_norm = typeof fv[4] === 'number' ? fv[4] : null;
+          membership = typeof fv[5] === 'number' ? fv[5] : null;
+          grad_re = typeof fv[6] === 'number' ? fv[6] : null;
+          grad_im = typeof fv[7] === 'number' ? fv[7] : null;
+          sensitivity = typeof fv[8] === 'number' ? fv[8] : null;
+
+          const patch = fv.slice(9);
+          if (patch.length > 0) {
+            let sum = 0;
+            let maxv = -Infinity;
+            for (let i = 0; i < patch.length; i++) {
+              const v = patch[i];
+              sum += v;
+              if (v > maxv) maxv = v;
+            }
+            patch_mean = sum / patch.length;
+            patch_max = maxv === -Infinity ? null : maxv;
+          }
+        }
+      } catch (e) {
+        // ignore context errors for telemetry
+      }
+    }
+
+    return {
+      ts: new Date().toISOString(),
+      model_dx,
+      model_dy,
+      applied_delta,
+      c_real,
+      c_imag,
+      prev_dx,
+      prev_dy,
+      nu_norm,
+      membership,
+      grad_re,
+      grad_im,
+      sensitivity,
+      patch_mean,
+      patch_max,
+      avg_rms: (this as any)._lastAvgRMS ?? null,
+      model_type: this.metadata?.model_type ?? null
+    };
   }
 
   /**


### PR DESCRIPTION
Implement server-side telemetry logging with a toggle in the Visualizer, allowing users to enable or disable logging. Introduce a diagnostic ping endpoint and add unit tests for the telemetry API endpoints.